### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Include a `<script>` on your `html` file:
 <script src="/your/path/to/jquery-socialshare.min.js"></script>
 ```
 
+or include it via CDN: 
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/jquery-socialshare/dist/js/jquery-socialshare.min.js"></script>
+```
+
 Configure your links/buttons with a class for the corresponding template:
 ```html
 <div class="social-container">


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/jquery-socialshare) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.